### PR TITLE
encoding/jsonに起因するバグを修正

### DIFF
--- a/server/table.go
+++ b/server/table.go
@@ -50,7 +50,7 @@ func (t *Table) ToItems() []Item {
 	t.mux.Lock()
 	defer t.mux.Unlock()
 
-	var items []Item
+	items := make([]Item, 0)
 	for _, k := range t.keys {
 		item := t.table[k].ToItem(k)
 		items = append(items, item)


### PR DESCRIPTION
`var items []Item` の形式で作ったsliceは `encoding/json` のバグで `null` になってしまう。

[*gin.Context.JSON turning empty array into null · Issue #125 · gin-gonic/gin](https://github.com/gin-gonic/gin/issues/125)

`make([]Item, 0)` の形式で作ったsliceは正しく `[]` になるので修正。