### PR TITLE
CopyからCopierにリネーム

### DIFF
--- a/server/copier.go
+++ b/server/copier.go
@@ -10,22 +10,22 @@ import (
 	"golang.org/x/xerrors"
 )
 
-type Copy struct {
+type Copier struct {
 	dir string
 	uid int
 	gid int
 }
 
-func NewLockCopy(dir string, uid int, gid int) *Copy {
-	return &Copy{
+func NewCopier(dir string, uid int, gid int) *Copier {
+	return &Copier{
 		dir: dir,
 		uid: uid,
 		gid: gid,
 	}
 }
 
-func (lc *Copy) Copy(r io.Reader, name string, ext string) error {
-	f, err := createNewFile(lc.dir, sanitize(name), sanitize(ext))
+func (c *Copier) Copy(r io.Reader, name string, ext string) error {
+	f, err := createNewFile(c.dir, sanitize(name), sanitize(ext))
 	if err != nil {
 		return xerrors.Errorf("failed to create file( name: %s, ext: %s ): %w", name, ext, err)
 	}
@@ -36,7 +36,7 @@ func (lc *Copy) Copy(r io.Reader, name string, ext string) error {
 		return xerrors.Errorf("failed to copy file( name: %s, ext: %s ): %w", name, ext, err)
 	}
 
-	err = os.Chown(f.Name(), lc.uid, lc.gid)
+	err = os.Chown(f.Name(), c.uid, c.gid)
 	if err != nil {
 		return xerrors.Errorf("failed to change owner( name: %s, ext: %s ): %w", name, ext, err)
 	}

--- a/server/copier_test.go
+++ b/server/copier_test.go
@@ -18,11 +18,11 @@ func TestCopyContents(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	lc := NewLockCopy(dir, 1000, 1000)
+	c := NewCopier(dir, 1000, 1000)
 	data := "ハローワールド"
 
 	buf := bytes.NewBuffer([]byte(data))
-	lc.Copy(buf, "azuki", "txt")
+	c.Copy(buf, "azuki", "txt")
 
 	// Read copied file
 	contents, err := ioutil.ReadFile(filepath.Join(dir, "azuki.txt"))
@@ -43,12 +43,12 @@ func TestCopyName(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	lc := NewLockCopy(dir, 1000, 1000)
+	c := NewCopier(dir, 1000, 1000)
 
 	buf := bytes.NewBuffer([]byte(""))
-	lc.Copy(buf, "azuki", "txt")
-	lc.Copy(buf, "azuki", "txt")
-	lc.Copy(buf, "azuki", "txt")
+	c.Copy(buf, "azuki", "txt")
+	c.Copy(buf, "azuki", "txt")
+	c.Copy(buf, "azuki", "txt")
 
 	// List copied files
 	fileInfos, err := ioutil.ReadDir(dir)

--- a/server/downloader.go
+++ b/server/downloader.go
@@ -11,17 +11,17 @@ import (
 
 type Downloader struct {
 	client ClientLike
-	copy   *Copy
+	copier *Copier
 	table  *Table
 }
 
 func NewDownloader(client ClientLike, dir string, uid int, gid int) *Downloader {
-	copy := NewLockCopy(dir, uid, gid)
+	copier := NewCopier(dir, uid, gid)
 	table := NewTable()
 
 	return &Downloader{
 		client: client,
-		copy:   copy,
+		copier: copier,
 		table:  table,
 	}
 }
@@ -75,7 +75,7 @@ func (d *Downloader) Download(url string, name string, ext string) error {
 
 	// Copy data from temp file to file unless canceled
 	if !pg.Canceled {
-		err = d.copy.Copy(temp, name, ext)
+		err = d.copier.Copy(temp, name, ext)
 		if err != nil {
 			return xerrors.Errorf("failed to copy with lock: %w", err)
 		}

--- a/server/downloader.go
+++ b/server/downloader.go
@@ -73,12 +73,14 @@ func (d *Downloader) Download(url string, name string, ext string) error {
 		return xerrors.Errorf("failed to seek temporary file: %w", err)
 	}
 
+	if pg.Canceled {
+		return xerrors.Errorf("cancelled downloading %s", name)
+	}
+
 	// Copy data from temp file to file unless canceled
-	if !pg.Canceled {
-		err = d.copier.Copy(temp, name, ext)
-		if err != nil {
-			return xerrors.Errorf("failed to copy with lock: %w", err)
-		}
+	err = d.copier.Copy(temp, name, ext)
+	if err != nil {
+		return xerrors.Errorf("failed to copy with lock: %w", err)
 	}
 
 	return nil

--- a/server/progress.go
+++ b/server/progress.go
@@ -31,7 +31,7 @@ func (pg *Progress) Write(p []byte) (int, error) {
 	defer pg.mux.Unlock()
 
 	if pg.Canceled {
-		return 0, xerrors.Errorf("%s is canceled", pg.name)
+		return 0, xerrors.Errorf("canceled downloading %s", pg.name)
 	}
 
 	n := len(p)


### PR DESCRIPTION
- `Downloader` の処理を改善